### PR TITLE
AT-2451 Convert to SDK style and dual-target with net472 and net10.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2026
 
 pull_requests:
   do_not_increment_build_number: true
@@ -37,12 +37,16 @@ artifacts:
     name: ThePlugin
     type: file
 
+  - path: src\AquaCalc5000\deploy\Release\AquaCalc5000-net10.plugin
+    name: ThePlugin-net10
+    type: file
+
 deploy:
   - provider: GitHub
     tag: v$(APPVEYOR_BUILD_VERSION)
     release: AquaCalc 5000 field data plugin $(APPVEYOR_BUILD_VERSION)
     description: ''
-    artifact: ThePlugin
+    artifact: ThePlugin, ThePlugin-net10
     auth_token: $(GITHUB_AUTH_TOKEN)
     on:
       is_not_pr: true

--- a/src/AquaCalc5000.UnitTests/AquaCalc5000.UnitTests.csproj
+++ b/src/AquaCalc5000.UnitTests/AquaCalc5000.UnitTests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <LangVersion>latest</LangVersion>
+    <LangVersion>latestMajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AquaCalc5000.UnitTests/AquaCalc5000.UnitTests.csproj
+++ b/src/AquaCalc5000.UnitTests/AquaCalc5000.UnitTests.csproj
@@ -1,84 +1,34 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B71F520F-A47C-4A7C-93F5-4BD9AB6B931C}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>AquaCalc5000.UnitTests</RootNamespace>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AssemblyName>AquaCalc5000.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <RootNamespace>AquaCalc5000.UnitTests</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Deterministic>true</Deterministic>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <PlatformTarget>x64</PlatformTarget>
+    <IsPackable>false</IsPackable>
+    <AquariusFieldDataFrameworkVersion>26.3.3</AquariusFieldDataFrameworkVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="FieldDataPluginFramework, Version=2.9.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\Aquarius.FieldDataFramework.20.2.0\lib\net472\FieldDataPluginFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <!-- Unlike the plugin project, tests run standalone (no host pre-loading FieldDataPluginFramework
+         into the AssemblyLoadContext), so both TFMs need the actual runtime DLL copied to output. -->
+    <PackageReference Include="Aquarius.FieldDataFramework" Version="$(AquariusFieldDataFrameworkVersion)" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="Mappers\ActivityMapperTests.cs" />
-    <Compile Include="Mappers\VerticalMapperTests.cs" />
-    <Compile Include="Mappers\VisitMapperTests.cs" />
-    <Compile Include="Parsers\AquaCalcCsvParserTests.cs" />
-    <Compile Include="Parsers\CsvParserTests.cs" />
-    <Compile Include="Parsers\ErrorFlagParserTests.cs" />
-    <Compile Include="Parsers\HeaderParserTests.cs" />
-    <Compile Include="Parsers\ObservationSectionParserTests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TestBase.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
     <EmbeddedResource Include="TestData\AquaCalc5000Test.csv" />
     <EmbeddedResource Include="TestData\NotAquaCalc5000.csv" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\AquaCalc5000\AquaCalc5000.csproj">
-      <Project>{0e35d023-8a8c-4d60-bb2f-69832059f933}</Project>
-      <Name>AquaCalc5000</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\AquaCalc5000\AquaCalc5000.csproj" />
   </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
-  </Target>
 </Project>

--- a/src/AquaCalc5000.UnitTests/Parsers/CsvParserTests.cs
+++ b/src/AquaCalc5000.UnitTests/Parsers/CsvParserTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+using System;
+using System.Linq;
 using AquaCalc5000.Parsers;
 using NUnit.Framework;
 
@@ -34,7 +35,7 @@ namespace AquaCalc5000.UnitTests.Parsers
         public void GetRequiredStringValueByLabel_ThrowsIfValueNotFound(string csv, string label)
         {
             var parser = new CsvParser(csv);
-            Assert.That(() => parser.GetRequiredStringByLabel(label), Throws.ArgumentException);
+            Assert.Throws<ArgumentException>(() => parser.GetRequiredStringByLabel(label));
         }
 
         [Test]

--- a/src/AquaCalc5000.UnitTests/packages.config
+++ b/src/AquaCalc5000.UnitTests/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Aquarius.FieldDataFramework" version="20.2.0" targetFramework="net472" />
-  <package id="NUnit" version="3.12.0" targetFramework="net472" />
-</packages>

--- a/src/AquaCalc5000/AquaCalc5000.csproj
+++ b/src/AquaCalc5000/AquaCalc5000.csproj
@@ -10,12 +10,12 @@
     <!-- NU1702: NuGet resolves against the framework's stated lib\net10.0 (there isn't a
          separate exact-match asset), which is expected here — the same net472 binary is
          republished under lib\net10.0 since it loads fine in .NET 10. -->
-    <NoWarn>$(NoWarn);NU1702</NoWarn>
+    <NoWarn Condition="'$(TargetFramework)' == 'net10.0'">$(NoWarn);NU1702</NoWarn>
     <AquariusFieldDataFrameworkVersion>26.3.3</AquariusFieldDataFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <LangVersion>latest</LangVersion>
+    <LangVersion>latestMajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,7 +40,9 @@
   </PropertyGroup>
 
   <!-- '$(TargetFramework)' != '' guards against the outer multi-targeting dispatch build running with an empty $(TargetPath). -->
-  <Target Name="PackageAndTestPlugin" AfterTargets="Build" Condition="'$(TargetFramework)' != '' And Exists('$(PluginPackagerExe)') And Exists('$(PluginTesterExe)')">
+  <Target Name="PackageAndTestPlugin" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
+    <Error Condition="!Exists('$(PluginPackagerExe)')" Text="PluginPackagerExe not found at '$(PluginPackagerExe)' - check the Aquarius.FieldDataFramework package version/path." />
+    <Error Condition="!Exists('$(PluginTesterExe)')" Text="PluginTesterExe not found at '$(PluginTesterExe)' - check the Aquarius.FieldDataFramework package version/path." />
     <Exec Command="&quot;$(PluginPackagerExe)&quot; &quot;$(TargetPath)&quot; /OutputPath=&quot;$(ProjectDir)deploy\$(Configuration)\$(PackagedPluginName)&quot;" />
     <!-- $(MSBuildProjectDirectory), not $(SolutionDir), so this also works building the .csproj directly
          (e.g. `dotnet build src\AquaCalc5000\AquaCalc5000.csproj`) without a solution context. -->

--- a/src/AquaCalc5000/AquaCalc5000.csproj
+++ b/src/AquaCalc5000/AquaCalc5000.csproj
@@ -1,79 +1,49 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{0E35D023-8A8C-4D60-BB2F-69832059F933}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>AquaCalc5000</RootNamespace>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AssemblyName>AquaCalc5000</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <RootNamespace>AquaCalc5000</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Deterministic>true</Deterministic>
     <PlatformTarget>x64</PlatformTarget>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- NU1702: NuGet resolves against the framework's stated lib\net10.0 (there isn't a
+         separate exact-match asset), which is expected here — the same net472 binary is
+         republished under lib\net10.0 since it loads fine in .NET 10. -->
+    <NoWarn>$(NoWarn);NU1702</NoWarn>
+    <AquariusFieldDataFrameworkVersion>26.3.3</AquariusFieldDataFrameworkVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <PlatformTarget>x64</PlatformTarget>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="FieldDataPluginFramework, Version=2.9.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\Aquarius.FieldDataFramework.20.2.0\lib\net472\FieldDataPluginFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="Aquarius.FieldDataFramework" Version="$(AquariusFieldDataFrameworkVersion)" Condition="'$(TargetFramework)' == 'net472'" />
+    <!-- ExcludeAssets="runtime" keeps this a compile-time-only reference for net10.0 — the
+         framework dll is already loaded into the Default AssemblyLoadContext by the host;
+         copying a second private copy to bin\ causes an InvalidCastException. -->
+    <PackageReference Include="Aquarius.FieldDataFramework" Version="$(AquariusFieldDataFrameworkVersion)" ExcludeAssets="runtime" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Config\Config.cs" />
-    <Compile Include="Config\ConfigLoader.cs" />
-    <Compile Include="Mappers\ActivityMapper.cs" />
-    <Compile Include="Mappers\CommonMapper.cs" />
-    <Compile Include="Mappers\VerticalMapper.cs" />
-    <Compile Include="Mappers\VisitMapper.cs" />
-    <Compile Include="Parsers\AquaCalcConstants.cs" />
-    <Compile Include="Parsers\AquaCalcCsvParser.cs" />
-    <Compile Include="Parsers\CsvLine.cs" />
-    <Compile Include="Parsers\CsvParser.cs" />
-    <Compile Include="Parsers\ErrorFlagParser.cs" />
-    <Compile Include="Parsers\HeaderParser.cs" />
-    <Compile Include="Parsers\VerticalObservation.cs" />
-    <Compile Include="Parsers\ObservationPoint.cs" />
-    <Compile Include="Parsers\ObservationSectionParser.cs" />
-    <Compile Include="Parsers\ParsedData.cs" />
-    <Compile Include="Plugin.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SystemCode\Parameters.cs" />
-    <Compile Include="SystemCode\Units.cs" />
-  </ItemGroup>
+
   <ItemGroup>
     <None Include="Config.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
   <PropertyGroup>
-    <PostBuildEvent>$(SolutionDir)packages\Aquarius.FieldDataFramework.20.2.0\tools\PluginPackager.exe $(TargetPath) /OutputPath=$(ProjectDir)deploy\$(Configuration)\$(TargetName).plugin
-$(SolutionDir)packages\Aquarius.FieldDataFramework.20.2.0\tools\PluginTester.exe /Plugin=$(TargetPath) /Data=$(SolutionDir)..\data\*.csv</PostBuildEvent>
+    <PluginPackagerExe>$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\$(TargetFramework)\PluginPackager.exe</PluginPackagerExe>
+    <PluginTesterExe>$(NuGetPackageRoot)\aquarius.fielddataframework\$(AquariusFieldDataFrameworkVersion)\tools\$(TargetFramework)\PluginTester.exe</PluginTesterExe>
+    <PackagedPluginName Condition="'$(TargetFramework)' == 'net472'">$(AssemblyName).plugin</PackagedPluginName>
+    <PackagedPluginName Condition="'$(TargetFramework)' == 'net10.0'">$(AssemblyName)-net10.plugin</PackagedPluginName>
   </PropertyGroup>
+
+  <!-- '$(TargetFramework)' != '' guards against the outer multi-targeting dispatch build running with an empty $(TargetPath). -->
+  <Target Name="PackageAndTestPlugin" AfterTargets="Build" Condition="'$(TargetFramework)' != '' And Exists('$(PluginPackagerExe)') And Exists('$(PluginTesterExe)')">
+    <Exec Command="&quot;$(PluginPackagerExe)&quot; &quot;$(TargetPath)&quot; /OutputPath=&quot;$(ProjectDir)deploy\$(Configuration)\$(PackagedPluginName)&quot;" />
+    <!-- $(MSBuildProjectDirectory), not $(SolutionDir), so this also works building the .csproj directly
+         (e.g. `dotnet build src\AquaCalc5000\AquaCalc5000.csproj`) without a solution context. -->
+    <Exec Command="&quot;$(PluginTesterExe)&quot; /Plugin=&quot;$(TargetPath)&quot; /Data=&quot;$(MSBuildProjectDirectory)\..\..\data\*.csv&quot;" />
+  </Target>
 </Project>

--- a/src/AquaCalc5000/packages.config
+++ b/src/AquaCalc5000/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Aquarius.FieldDataFramework" version="20.2.0" targetFramework="net472" />
-</packages>


### PR DESCRIPTION
@AquaticInformatics/artemis @AquaticInformatics/nautilus

Switching the project to SDK-style, and dual-targeting to net10. Changes include

- updating the appveyor image to 2026, allowing net10
- dual-targets the unit tests too, so tests are run against both net472 and net10
- adds PluginPackagerExe and PluginTesterExe for the net10 build, so both net472 and net10 are tested on build
